### PR TITLE
Add config file, reference counter and limited email functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ python 2.7
 
 ## Installation
 
-Clone the repository and change to its root directory and run
+Clone the repository and change to its root directory,
+change your email settings in 'config.ini' and run
 
 ```
 pip install -r requirements.txt

--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
+# -*- coding=utf-8 -*-
 from flask import Flask
 from flask import request
+from flask_mail import Mail, Message
 
 from pymongo import MongoClient
 
@@ -11,17 +13,68 @@ from time import time
 
 from flask_cors import CORS, cross_origin
 
+import ConfigParser
+from string import Template
+
 app = Flask(__name__)
 CORS(app)
 
 client = MongoClient('localhost', 27017)
 db = client.fuusio70
 
+def init_config(config_name):
+    config = ConfigParser.SafeConfigParser()
+    config.optionxform = str
+    config.read(config_name)
+    settings  = dict()
+    app.config.update(**dict(config.items('Email')))
+    for section in config.sections():
+        settings.update({section : dict(config.items(section))})
+    if db.config.find_one() is None:
+        db.config.save(settings)
+    else:
+        db.config.update({'_id': db.config.find_one().get('_id')}, settings, upsert=True)
+    if not db.config.find_one({'referenceCounter': { '$exists': 1}}):
+        db.config.update({'referenceCounter': { '$exists': 1}},{'referenceCounter': db.config.find_one({}, {'Billing': 1, '_id': 0}).get('Billing').get('InitialReference')}, upsert=True)
+
+def reference_counter():
+    reference_number = db.config.find_one({'referenceCounter':{'$exists': 1}})
+    db.config.update({'_id': reference_number.get('_id')}, {'referenceCounter': int(reference_number.get('referenceCounter')) +1})
+    return int(reference_number.get('referenceCounter')) +1
+    
+def send_mail(user_data): # done for a specific case for Fuusi70
+    settings = db.config.find_one()
+    email_templates = settings.get('Email_templates')
+    billing = settings.get('Billing')
+    if user_data['status'] == u'student':
+        sum = int(billing.get('StudentPrice'))
+    else:
+        sum = int(billing.get('DefaultPrice'))
+    if user_data['sillis'] == 'true':
+        sum += int(billing.get('Sillis'))
+    if user_data['historyOrder'] == 'true':
+        sum += int(billing.get('HistoryManuscript'))
+    if user_data['historyDeliveryMethod'] == 'true':
+        sum += int(billing.get('PostDelivery'))
+    email_templates.update({'sum' : sum})
+    email_templates.update(user_data)
+    
+    if user_data['status'] == 'inviteGuest' or user_data['status'] == 'supporter':
+        letter = Template(email_templates.get('ThankYouLetter')).safe_substitute(email_templates)
+    else:
+        letter = Template(email_templates.get('Bill')).safe_substitute(email_templates)
+    msg = Message(email_templates.get('MailHeader'), sender=(email_templates.get('SenderEmailName'), email_templates.get('SenderEmailAddress')), recipients=[user_data['email']])
+    msg.body = letter
+    mail.send(msg)
+
+init_config('config.ini')
+mail = Mail(app)
 
 @app.route('/users/<user_id>', methods=['GET'])
 def user_read(user_id):
-    user = db.users.find_one({'_id': ObjectId(user_id)})
+    user = db.users.findOne({'_id': ObjectId(user_id)})
     return json.dumps(user, default=json_util.default)
+
 
 
 @app.route('/users', methods=['GET'])
@@ -41,7 +94,9 @@ def users_update():
     data = json.loads(raw_data)
     user = data['formData']
     user_id = data['userId']
+    user['referenceNumber'] = reference_counter()
     db.users.update({'_id': ObjectId(user_id)}, {'$set': user})
+    send_mail(user)
     return json.dumps({'userId': str(user_id)})
 
 
@@ -59,6 +114,7 @@ def users_create():
         'historyDeliveryMethod': '',
         'historyOrder': '',
         'name': '',
+		'referenceNumber': '',
         'sillis': '',
         'status': '',
         'table': '',

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,50 @@
+[Billing]
+HistoryManuscript = 35
+StudentPrice = 85
+InitialReference = 100001
+PostDelivery = 10
+DefaultPrice = 110
+Sillis = 20
+
+[Email]
+MAIL_SERVER = smtp.gmail.com
+MAIL_USE_SSL = 1
+DEBUG = 1
+MAIL_PASSWORD = APG64fUP
+MAIL_PORT = 465
+MAIL_USERNAME = vadim.gurkalov@gmail.com 
+
+[Email_templates]
+MailHeader = Fuusio 70
+SenderEmailName = Fuusio70
+SenderEmailAddress = ilmo@fyysikkokilta.fi
+SenderTitle = Baz
+DueDate = 6.9.2013
+SenderName = Foo
+AccountNumber = FI10R3M
+BIC = FIIPSUM
+Recipient = Fyyysikkokilta ry
+Bill = Dear $name,
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla nec auctor risus. Donec blandit, urna nec porta laoreet, ante tortor gravida augue, vel fringilla lorem velit in velit. Nam ac finibus dui. Cras ac placerat nisl. Aliquam a lorem non nibh lacinia fermentum. Morbi consequat, felis quis faucibus eleifend, nisi libero auctor massa, et posuere elit metus quis dui. Pellentesque et facilisis mauris, sit amet congue erat.
+	
+	Tilinumero: $AccountNumber
+	BIC: $BIC
+	Saaja: $Recipient
+	Viitenumero: $referenceNumber
+	Summa: $sum 
+	Eräpäivä: $DueDate
+	
+	Ystävällisin yhteistyöterveisin,
+	$SenderName
+	$SenderTitle
+	Fyysikkokilta ry
+ThankYouLetter = Dear $name,
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla nec auctor risus. Donec blandit, urna nec porta laoreet, ante tortor gravida augue, vel fringilla lorem velit in velit. Nam ac finibus dui. Cras ac placerat nisl. Aliquam a lorem non nibh lacinia fermentum. Morbi consequat, felis quis faucibus eleifend, nisi libero auctor massa, et posuere elit metus quis dui. Pellentesque et facilisis mauris, sit amet congue erat.
+	
+	Proin aliquet sapien et nibh posuere pulvinar. Integer cursus, arcu nec tempor vestibulum, orci purus interdum nisl, eu tincidunt nibh nisi nec est. Donec tincidunt vel ex at interdum. Suspendisse consectetur libero ut neque hendrerit, sed ultricies purus accumsan. Nam eu porttitor nibh. Aenean vel libero est. Donec dignissim arcu nulla, in rutrum augue ultricies ut. Fusce a ipsum metus.
+	
+	Ystävällisin yhteistyöterveisin,
+	$SenderName
+	$SenderTitle
+	Fyysikkokilta ry
+

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,65 @@
+from flask_mail import Mail, Message
+
+import ConfigParser
+
+from pymongo import MongoClient
+from string import Template
+
+client = MongoClient('localhost', 27017)
+db = client.fuusio70
+
+class Config:
+    
+    def __init__(flask_app, mongo_db):
+        self.config = ConfigParser.SafeConfigParser()
+        self.db = mongo_db
+
+    
+    def init_config(config_name):
+        config.optionxform = str
+        config.read(config_name)
+        settings  = dict()
+        app.config.update(**dict(config.items('Email')))
+        for section in config.sections():
+        settings.update({section : dict(config.items(section))})
+        if db.config.find_one() is None:
+                db.config.save(settings)
+        else:
+            db.config.update({'_id': db.config.find_one().get('_id')}, settings, upsert=True)
+        if db.config.find_one({'referenceCounter': { '$exists': 1}}):
+            db.config.update({'referenceCounter': { '$exists': 1}},{'referenceCounter': db.config.find_one({}, {'InitialReference': 1, '_id': 0}).get('InitialReference')}, upsert=True)
+    
+    def reference_counter ()
+        reference_number = db.config.find_one({'referenceCounter':{'$exists': 1}})
+        db.config.update({'_id': reference_number.get('_id')}, {'referenceCounter': int(reference_number.get('referenceCounter')) +1})
+        return int(reference_number.get('referenceCounter')) +1
+    
+class Mail_sender:
+    def __init__(flask_app, mongo_db):
+        self.mail = Mail(flask_app)
+        self.db = mongo_db
+    
+    def send_mail(user_data): # done for a specific case for Fuusi70
+    settings = db.config.find_one()
+    email_templates = settings.get('Email_templates')
+    billing = settings.get('Billing')
+    if user_data['status'] == u'student':
+        sum = int(billing.get('StudentPrice'))
+    else:
+        sum = int(billing.get('DefaultPrice'))
+    if user_data['sillis'] == 'true':
+        sum += int(billing.get('Sillis'))
+    if user_data['historyOrder'] == 'true':
+        sum += int(billing.get('HistoryManuscript'))
+    if user_data['historyDeliveryMethod'] == 'true':
+        sum += int(billing.get('PostDelivery'))
+    email_templates.update({'sum' : sum})
+    email_templates.update(user_data)
+    
+    if user_data['status'] == 'inviteGuest' or user_data['status'] == 'supporter':
+        letter = Template(email_templates.get('ThankYouLetter')).safe_substitute(settings)
+    else:
+        letter = Template(email_templates.get('Bill')).safe_substitute(settings)
+    msg = Message(email_templates.get('MailHeader'), sender=(email_templates.get('SenderEmailName'), email_templates.get('SenderEmailAddress')), recipients=[user_data['email']])
+    msg.body = letter
+    mail.send(msg)


### PR DESCRIPTION
Add ability to read and act on 'config.ini'.

Add reference counter which unless already exists will initialize from
config and will be persistent between sessions. Counter will tick after
each sign up.

Add ability to send emails from config files template. Currently has
been only tested and working only on Gmail.